### PR TITLE
Be explicit about lan_subnets for Azure deployments.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -404,8 +404,8 @@ locals {
   cidrbits      = tonumber(split("/", local.cidr)[1])
   newbits       = 28 - local.cidrbits
   netnum        = pow(2, local.newbits)
-  lan_subnet    = try(coalesce(var.lan_subnet), cidrsubnet(local.cidr, local.newbits, 4))
-  ha_lan_subnet = try(coalesce(var.ha_lan_subnet), cidrsubnet(local.cidr, local.newbits, 8))
+  lan_subnet    = try(coalesce(var.lan_subnet, cidrsubnet(local.cidr, local.newbits, 4)))
+  ha_lan_subnet = try(coalesce(var.ha_lan_subnet, cidrsubnet(local.cidr, local.newbits, 8)))
 
   fqdn_lan_vpc_id  = local.cloud == "gcp" ? local.lan_vpc.vpc_id : null
   fqdn_lan_cidr    = lookup(local.fqdn_lan_cidr_map, local.cloud, null)

--- a/variables.tf
+++ b/variables.tf
@@ -240,6 +240,18 @@ variable "key_name" {
   default     = null
 }
 
+variable "lan_subnet" {
+  description = "Applicable to Azure deployment only. Be explicit about which subnet to deploy FQDN gateways."
+  type        = string
+  default     = null
+}
+
+variable "ha_lan_subnet" {
+  description = "Applicable to Azure deployment only. Be explicit about which subnet to deploy ha FQDN gateways."
+  type        = string
+  default     = null
+}
+
 locals {
   #Gather transit module details in locals, for easy reference
   transit_gateway               = var.transit_module.transit_gateway
@@ -392,8 +404,8 @@ locals {
   cidrbits      = tonumber(split("/", local.cidr)[1])
   newbits       = 28 - local.cidrbits
   netnum        = pow(2, local.newbits)
-  lan_subnet    = cidrsubnet(local.cidr, local.newbits, 4)
-  ha_lan_subnet = cidrsubnet(local.cidr, local.newbits, 8)
+  lan_subnet    = try(coalesce(var.lan_subnet), cidrsubnet(local.cidr, local.newbits, 4))
+  ha_lan_subnet = try(coalesce(var.ha_lan_subnet), cidrsubnet(local.cidr, local.newbits, 8))
 
   fqdn_lan_vpc_id  = local.cloud == "gcp" ? local.lan_vpc.vpc_id : null
   fqdn_lan_cidr    = lookup(local.fqdn_lan_cidr_map, local.cloud, null)


### PR DESCRIPTION
Hi, this was a fix we did for deploying the firenet module in Azure, adds possibility to override the lan subnet CIDRs.

Tried to fix it filtering on specific subnet names in this, now closed, PR https://github.com/terraform-aviatrix-modules/terraform-aviatrix-mc-firenet/pull/11. However, dmz-lan subnets are not present in the vpc output in transit module as of now. Logic in above PR can be combined with these additional variables of course. Let me know what you think.

```terraform
module "mc_transit" {
  source  = "terraform-aviatrix-modules/mc-transit/aviatrix"
  version = "v2.3.1"

  cloud                  = var.cloud
  cidr                   = var.cidr
  region                 = var.region
  account                = var.account
  name                   = var.name
  gw_name                = var.gw_name
  local_as_number        = var.local_as_number
  enable_transit_firenet = var.enable_transit_firenet
  enable_segmentation    = var.enable_segmentation
  resource_group         = var.resource_group
  instance_size          = var.instance_size
}

module "firenet" {
  source  = "terraform-aviatrix-modules/mc-firenet/aviatrix"
  version = "v1.3.0"
  transit_module = module.mc_transit
  firewall_image = var.firewall_image
  instance_size  = var.instance_size

  # Override to deploy gws in correct subnets
  lan_subnet     = var.lan_subnet
  ha_lan_subnet  = var.ha_lan_subnet
}
```