### PR TITLE
Add filtering for subnets for Azure deployments.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -411,7 +411,7 @@ locals {
   newbits       = 28 - local.cidrbits
   netnum        = pow(2, local.newbits)
   lan_subnet    = local.azure_lan_subnet != null ? local.azure_lan_subnet : cidrsubnet(local.cidr, local.newbits, 4)
-  ha_lan_subnet = local.azure_lan_subnet != null ? local.azure_lan_subnet : cidrsubnet(local.cidr, local.newbits, 4)
+  ha_lan_subnet = local.azure_halan_subnet != null ? local.azure_halan_subnet : cidrsubnet(local.cidr, local.newbits, 8)
 
   fqdn_lan_vpc_id  = local.cloud == "gcp" ? local.lan_vpc.vpc_id : null
   fqdn_lan_cidr    = lookup(local.fqdn_lan_cidr_map, local.cloud, null)


### PR DESCRIPTION
Tested by parsing outputs from mc_transit module.

``` terraform
locals {
  azure_halan_subnet = (
    var.cloud == "Azure" ?
       try(element([
        for subnet in module.mc_transit.vpc.public_subnets
        : subnet.cidr if endswith(subnet.name, "ingress-egress-1")
       ], 0), null)
      : null
    )
}

output "subnets" {
  value = local.azure_halan_subnet
}
```

yields correct subnet CIDR. But the dmz subnets are not provided as outputs by VPC module meaning this won't be that useful.