### PR TITLE
Ignore enable_vpc_dns_server for egress gws

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,6 +126,11 @@ resource "aviatrix_gateway" "egress_instance_1" {
   fault_domain        = local.fault_domain
   fqdn_lan_vpc_id     = local.fqdn_lan_vpc_id
   fqdn_lan_cidr       = local.fqdn_lan_cidr
+  lifecycle {
+    ignore_changes = [
+      enable_vpc_dns_server # aviatrix_fqdn gw_filter_tag_list modifies this value on the gateway
+    ]
+  }
 }
 
 resource "aviatrix_gateway" "egress_instance_2" {
@@ -143,6 +148,11 @@ resource "aviatrix_gateway" "egress_instance_2" {
   fault_domain        = local.ha_fault_domain
   fqdn_lan_vpc_id     = local.fqdn_lan_vpc_id
   fqdn_lan_cidr       = local.ha_fqdn_lan_cidr
+  lifecycle {
+    ignore_changes = [
+      enable_vpc_dns_server # aviatrix_fqdn gw_filter_tag_list modifies this value on the gateway
+    ]
+  }
 }
 
 #Firenet


### PR DESCRIPTION
Workaround for the `aviatrix_gateway` and `aviatrix_fqdn` resources managing the same setting on standalone egress gateways. Noted in the [provider documentation](https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs/resources/aviatrix_fqdn#enable_vpc_dns_server).