### PR TITLE
Fixed dmz-firewall-lan subnet for Egress FQDN

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -393,7 +393,7 @@ locals {
   cidrbits      = tonumber(split("/", local.cidr)[1])
   newbits       = 28 - local.cidrbits
   netnum        = pow(2, local.newbits)
-  lan_subnet    = cidrsubnet(local.cidr, local.newbits, 4)
+  lan_subnet    = cidrsubnet(local.cidr, local.newbits, 5)
   ha_lan_subnet = cidrsubnet(local.cidr, local.newbits, 8)
 
   fqdn_lan_vpc_id  = local.cloud == "gcp" ? local.lan_vpc.vpc_id : null


### PR DESCRIPTION
Modified the dmz-firewall-lan subnet when deploying FQDN gateways, the current index causes deployment of primary FQDN gateway to fail