### PR TITLE
version v1.6.0 -> provider constaint to 3.2.0

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,7 +2,7 @@
 Module version | Terraform version | Controller version | Terraform provider version | [mc-transit module](https://github.com/terraform-aviatrix-modules/terraform-aviatrix-mc-transit) version
 :--- | :--- | :--- | :--- | :---
 v8.0.0 | >=1.3.0 | >= 8.0 | >= 8.0.0 | >= v8.0.0
-v1.6.0 | >=1.3.0 | >= 7.2 | ~> 3.1.0 | ~> v2.6.0
+v1.6.0 | >=1.3.0 | >= 7.2 | ~> 3.2.0 | ~> v2.6.0
 v1.5.4 | >=1.1.0 | >= 7.1 | ~> 3.1.0 | ~> v2.5.2
 v1.5.3 | >=1.1.0 | >= 7.1 | ~> 3.1.0 | ~> v2.5.0
 v1.5.2 | >=1.1.0 | >= 7.1 | ~> 3.1.0 | ~> v2.5.0


### PR DESCRIPTION
Version v.1.6.0 module should have constraint v3.2.0 it was originally ~> 3.1.0